### PR TITLE
Configure Hound to ignore schema file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - spec/example_app/db/schema.rb
+    - db/schema.rb
 
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.


### PR DESCRIPTION
There's no benefit to Hound reporting on files that are automatically generated. This makes it stop monitoring `db/schema.rb`