### PR TITLE
Create poem from submission form

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,12 +1,20 @@
 class SubmissionsController < ApplicationController
   def new
     @submission = Submission.new
+    @submission.build_poem
   end
 
   def create
-    @submission = current_user.submissions.create(submission_params)
-    @submission.persisted? && @submission.poems.create(extract_poem_params)
+    @submission = current_user.submissions.build(submission_params)
+    # Slightly problematic because it creates duplication. Unless the app allows
+    # users to collaborate, a poem owner will always be a packet owner and will
+    # always be a submission owner. No quick fix available, but bears chewing
+    # on.
+    @submission.submission_packets.each do |packet|
+      packet.poem.user_id = current_user.id
+    end
 
+    @submission.save
     respond_with @submission
   end
 
@@ -17,17 +25,14 @@ class SubmissionsController < ApplicationController
   private
 
   def submission_params
-    extract_poem_params
     params.require(:submission).permit(
       :title,
       :submitted_to,
       :status,
       poem_ids: [],
+      submission_packets_attributes: [
+        poem_attributes: [:title, :status],
+      ],
     )
-  end
-
-  def extract_poem_params
-    @_poem_params ||= params[:submission].delete(:poem)
-    @_poem_params.permit(:title, :status).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -4,7 +4,8 @@ class SubmissionsController < ApplicationController
   end
 
   def create
-    @submission = Submission.create(submission_params_with_user)
+    @submission = current_user.submissions.create(submission_params)
+    @submission.persisted? && @submission.poems.create(extract_poem_params)
 
     respond_with @submission
   end
@@ -16,6 +17,7 @@ class SubmissionsController < ApplicationController
   private
 
   def submission_params
+    extract_poem_params
     params.require(:submission).permit(
       :title,
       :submitted_to,
@@ -24,7 +26,8 @@ class SubmissionsController < ApplicationController
     )
   end
 
-  def submission_params_with_user
-    submission_params.merge(user_id: current_user.id)
+  def extract_poem_params
+    @_poem_params ||= params[:submission].delete(:poem)
+    @_poem_params.permit(:title, :status).merge(user_id: current_user.id)
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -15,7 +15,28 @@ class Submission < ApplicationRecord
   has_many :submission_packets, dependent: :destroy
   has_many :poems, through: :submission_packets
 
+  accepts_nested_attributes_for :submission_packets,
+    reject_if: :deep_blank?
+
   validates :title, presence: true
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :submitted_to, presence: true
+
+  def build_poem(attributes = {})
+    submission_packets.build.build_poem(attributes)
+  end
+
+  # Could use benchmarking against other strategies like using `all`
+  # If I decide I want to make this private, the way to do that is to factor
+  # this logic away into and object and make the `Submission#deep_blank?` pass
+  # attributes an instance of it.
+  def deep_blank?(attributes)
+    if attributes.blank?
+      true
+    elsif attributes.respond_to?(:values)
+      attributes.reject { |_key, value| deep_blank?(value) }.empty?
+    else
+      false
+    end
+  end
 end

--- a/app/models/submission_packet.rb
+++ b/app/models/submission_packet.rb
@@ -1,4 +1,6 @@
 class SubmissionPacket < ApplicationRecord
   belongs_to :poem
   belongs_to :submission
+
+  accepts_nested_attributes_for :poem
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,5 @@ class User < ApplicationRecord
   include Clearance::User
 
   has_many :poems, dependent: :destroy
+  has_many :submissions
 end

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -7,9 +7,15 @@
   <%= form.input :submitted_to %>
   <%= form.input :status, collection: Submission::STATUSES %>
   <%= form.association :poems, as: :check_boxes %>
-  <%= form.simple_fields_for :poem do |poem| %>
-    <%= poem.input :title, label: "New Poem Title", required: false %>
-    <%= poem.input :status, label: "New Poem Status", collection: Poem::STATUSES, required: false %>
+  <%= form.simple_fields_for :submission_packets do |packet_form| %>
+    <%= packet_form.simple_fields_for :poem do |poem_form| %>
+      <%= poem_form.input :title, label: "New Poem Title", required: false %>
+      <%= poem_form.input :status, 
+        label: "New Poem Status",
+        collection: Poem::STATUSES,
+        required: false
+      %>
+    <% end %>
   <% end %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -7,5 +7,9 @@
   <%= form.input :submitted_to %>
   <%= form.input :status, collection: Submission::STATUSES %>
   <%= form.association :poems, as: :check_boxes %>
+  <%= form.simple_fields_for :poem do |poem| %>
+    <%= poem.input :title, label: "New Poem Title", required: false %>
+    <%= poem.input :status, label: "New Poem Status", collection: Poem::STATUSES, required: false %>
+  <% end %>
   <%= form.button :submit %>
 <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,4 +9,11 @@ FactoryGirl.define do
     title "The Best Poem"
     status "Ready"
   end
+
+  factory :submission do
+    user
+    title "New Submission"
+    submitted_to "Magnificent Publication"
+    status Submission::STATUSES.first
+  end
 end

--- a/spec/features/submission_spec.rb
+++ b/spec/features/submission_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature "User creates a submission" do
       )
       expect(page).to have_text(submission_title)
       expect(page).to have_text(poem.title)
+      expect(user.submissions.first.poems.size).to eq(1)
     end
   end
 
@@ -42,16 +43,18 @@ RSpec.feature "User creates a submission" do
       fill_in :submission_submitted_to, with: submitted_to
       select submission_status, from: :submission_status
       check existing_poem.title
-      fill_in :poem_title, with: new_poem_title
-      select poem_status, from: :poem_status
-      submit.form
+      fill_in "New Poem Title", with: new_poem_title
+      select poem_status, from: "New Poem Status"
+      submit_form
+
+      expect(page).to have_text(submission_title)
+      expect(page).to have_text(new_poem_title)
 
       expect(page).to have_flash_message(
         :notice,
-        text: t("flash.actions.create.notice"),
+        text: "Submission was successfully created.",
       )
-      expect(page).to have_text(submission_title)
-      expect(page).to have_text(new_poem_title)
+      expect(user.submissions.first.poems.size).to eq 2
     end
   end
 

--- a/spec/features/submission_spec.rb
+++ b/spec/features/submission_spec.rb
@@ -49,7 +49,6 @@ RSpec.feature "User creates a submission" do
 
       expect(page).to have_text(submission_title)
       expect(page).to have_text(new_poem_title)
-
       expect(page).to have_flash_message(
         :notice,
         text: "Submission was successfully created.",

--- a/spec/features/submission_spec.rb
+++ b/spec/features/submission_spec.rb
@@ -26,6 +26,35 @@ RSpec.feature "User creates a submission" do
     end
   end
 
+  context "and creates a new poem" do
+    scenario "and is shown the submisison's show with the new poem" do
+      user = create(:user)
+      existing_poem = create(:poem, user: user)
+      submission_title = "New Work"
+      submission_status = Submission::STATUSES.first
+      submitted_to = "Vaunted Journal"
+      new_poem_title = "Lyle 2.-"
+      poem_status = Poem::STATUSES.first
+
+      visit root_path(as: user)
+      click_on t("submissions.actions.new")
+      fill_in :submission_title, with: submission_title
+      fill_in :submission_submitted_to, with: submitted_to
+      select submission_status, from: :submission_status
+      check existing_poem.title
+      fill_in :poem_title, with: new_poem_title
+      select poem_status, from: :poem_status
+      submit.form
+
+      expect(page).to have_flash_message(
+        :notice,
+        text: t("flash.actions.create.notice"),
+      )
+      expect(page).to have_text(submission_title)
+      expect(page).to have_text(new_poem_title)
+    end
+  end
+
   context "without selecting a poem" do
     scenario "and is shown the submission's show page" do
       user = create(:user)

--- a/spec/models/submission_packet_spec.rb
+++ b/spec/models/submission_packet_spec.rb
@@ -4,5 +4,6 @@ RSpec.describe SubmissionPacket do
   describe "associations" do
     it { is_expected.to belong_to(:submission) }
     it { is_expected.to belong_to(:poem) }
+    it { is_expected.to accept_nested_attributes_for(:poem) }
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Submission do
     it { is_expected.to validate_presence_of(:submitted_to) }
     it do
       is_expected.to validate_inclusion_of(:status).
-        in_array(Submission::SUBMISSION_STATUSES)
+        in_array(Submission::STATUSES)
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -14,5 +14,38 @@ RSpec.describe Submission do
   describe "assocations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to have_many(:poems).through(:submission_packets) }
+    it { is_expected.to accept_nested_attributes_for(:submission_packets) }
+  end
+
+  describe "#deep_blank?" do
+    context "when all of the attributes have no value" do
+      it "returns true" do
+        attributes = {
+          submission_packet_attributes: {
+            poem_attributes: {
+              title: "",
+              status: nil,
+            },
+          },
+        }
+
+        expect(Submission.new.deep_blank?(attributes)).to eq true
+      end
+    end
+
+    context "when an attribute has a value" do
+      it "returns false" do
+        attributes = {
+          submission_packet_attributes: {
+            poem_attributes: {
+              title: :bar_baby,
+              status: nil,
+            },
+          },
+        }
+
+        expect(Submission.new.deep_blank?(attributes)).to eq false
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,5 +3,6 @@ require 'rails_helper'
 RSpec.describe User do
   describe "associations" do
     it { is_expected.to have_many(:poems) }
+    it { is_expected.to have_many(:submissions) }
   end
 end


### PR DESCRIPTION
This PR is concerned with creating a new poem from the form to create a new submission.	The approach I've taken here works, but I'm skeptical of how sound it is. Essentially, I manually create the associated poem in `SubmissionsController` instead of using `accepts_nested_attributes_for` or creating a separate form object. I tried both of those approaches and failed with them.
 - I wasn't able to get `accepts_nested_attributes_for` wasn't properly assigning the `current_user` to the newly created poem. This approach allowed me to modify the params directly. I might've been able to use a `before_save` callback, but I recall thoughtbot having a style premise of avoiding them when possible. 
- I started to extract this to a service object, but found that the logic there was no different from what's currently in the controller and that it didn't fit with the eventual roadmap item of adding multiple new poems over AJAX while creating a new submission. 
-Eventually, I'd like to create this as a transaction or otherwise ensure that I don't have poems without a submission that are created if the submission fails to create. I'm sure there's a pattern I'm not using for this type of creation. The urge towards a transaction might be manageable by only creating new poems over AJAX. 