### PR TITLE
Rename app

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name":"submish",
+  "name":"imitable",
   "scripts":{},
   "env":{
     "APPLICATION_HOST":{

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h1>Inimitable</h1>
+  <h1>Imitable</h1>
   <div>
     <h2>Your Poems</h2>
     <% if @poems.present? %>
@@ -42,4 +42,5 @@
         class: "btn button"
     %>
   </div>
+  <div id="app"></div>
 </div>

--- a/bin/setup_review_app
+++ b/bin/setup_review_app
@@ -9,8 +9,8 @@ if [ -z "$1" ]; then
   exit 64
 fi
 
-PARENT_APP_NAME=submish-staging
-APP_NAME=submish-staging-pr-$1
+PARENT_APP_NAME=imitable-staging
+APP_NAME=imitable-staging-pr-$1
 URL=`heroku pg:backups public-url -a $PARENT_APP_NAME`
 
 heroku pg:backups restore $URL DATABASE_URL --confirm $APP_NAME --app $APP_NAME

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
 Bundler.require(*Rails.groups)
-module Submish
+module Imitable
   class Application < Rails::Application
     # Use the responders controller from the responders gem
     config.app_generators.scaffold_controller :responders_controller

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 development: &default
   adapter: postgresql
-  database: submish_development
+  database: imitable_development
   encoding: utf8
   min_messages: warning
   pool: <%= Integer(ENV.fetch("DB_POOL", 5)) %>
@@ -9,7 +9,7 @@ development: &default
 
 test:
   <<: *default
-  database: submish_test
+  database: imitable_test
 
 production: &deploy
   encoding: utf8

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_submish_session'
+Rails.application.config.session_store :cookie_store, key: "_imitable_session"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,25 +3,24 @@ Rails.application.routes.draw do
   resources :submissions, only: [:new, :create, :show]
   # begin Clearance routes
   resources :passwords,
-    controller: 'clearance/passwords',
+    controller: "clearance/passwords",
     only: [:create, :new]
 
-  resource :session, controller: 'clearance/sessions', only: [:create]
-
-  resources :users, 
-    controller: 'clearance/users',
+  resource :session, controller: "clearance/sessions", only: [:create]
+  resources :users,
+    controller: "clearance/users",
     only: Clearance.configuration.user_actions do
       resource :password,
-        controller: 'clearance/passwords',
+        controller: "clearance/passwords",
         only: [:create, :edit, :update]
     end
 
-  get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
-  delete '/sign_out' => 'clearance/session#delete', as: 'sign_out'
+  get "/sign_in" => "clearance/sessions#new", as: "sign_in"
+  delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
 
   if Clearance.configuration.allow_sign_up?
-    get '/sign_up' => 'clearance/users#new', as: 'sign_up'
+    get "/sign_up" => "clearance/users#new", as: "sign_up"
   end
   # end Clearance routes
-  root 'home#index'
+  root "home#index"
 end


### PR DESCRIPTION
The app had was still referring to itself by its old name, "Submish". This commit changes that. It also required a change to the underlying local database for anyone who's running a local copy of this
application. To do that, I had to drop into psql and run `ALTER DATABASE <current name> RENAME TO <new name>`.