### PR TITLE
Replace CapybaraWebkit with Chrome Headless

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "recipient_interceptor"
 gem "responders"
 gem "sass-rails", "~> 5.0"
 gem "simple_form"
-# gem "skylight"
 gem "sprockets", ">= 3.0.0"
 gem "suspenders"
 gem "title"
@@ -46,7 +45,7 @@ group :development, :staging do
 end
 
 group :test do
-  gem "capybara-webkit"
+  gem "capybara-selenium"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,9 +68,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.14.0)
-      capybara (>= 2.3.0, < 2.14.0)
-      json
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     clearance (1.16.0)
       bcrypt
       email_validator (~> 1.4)
@@ -211,6 +213,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -219,6 +222,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.11.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     simple_form (3.4.0)
@@ -281,7 +287,7 @@ DEPENDENCIES
   bourbon (~> 5.0.0.beta.7)
   bullet
   bundler-audit (>= 0.5.0)
-  capybara-webkit
+  capybara-selenium
   clearance
   database_cleaner
   delayed_job_active_record
@@ -326,4 +332,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/spec/features/poem_spec.rb
+++ b/spec/features/poem_spec.rb
@@ -14,7 +14,7 @@ feature "Poem management" do
       submit_form
 
       expect(page).to have_flash_message(
-        :notice, 
+        :notice,
         text: "Poem was successfully created"
       )
       expect(page).to have_content(poem_title)
@@ -39,6 +39,6 @@ feature "Poem management" do
         expect(page).to have_text("Title can't be blank")
       end
       expect(page).not_to have_content("Submitted to:")
-    end 
+    end
   end
 end

--- a/spec/support/capybara_chrome_headless.rb
+++ b/spec/support/capybara_chrome_headless.rb
@@ -1,0 +1,17 @@
+require "selenium/webdriver"
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) },
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome

--- a/spec/support/capybara_webkit.rb
+++ b/spec/support/capybara_webkit.rb
@@ -1,5 +1,0 @@
-Capybara.javascript_driver = :webkit
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
-end


### PR DESCRIPTION
Capybara Webkit can be a pain to set up on new machines since it only works through qt version 5.5. This replaces to use Chrome Headless for specs instead!